### PR TITLE
[Docs] add ADR-002, ADR-003, and ADR-004

### DIFF
--- a/docs/ADR-002-ssg-replacement.md
+++ b/docs/ADR-002-ssg-replacement.md
@@ -279,7 +279,6 @@ is configurable via `docs_dir` setting in `mkdocs.yml`.
 ### Negative
 
 - **Migration Effort**: One-time cost to convert existing Sphinx/reST content to MkDocs/Markdown format.
-  Estimated 5--7 days for comprehensive migration including testing and refinement.
 - **Feature Gaps**: Some advanced Sphinx features (sphinx-autodoc for Python API documentation, complex
   cross-referencing) have no direct equivalent. However, course content does not currently use these features.
 - **Plugin Dependency for i18n**: Localization is plugin-based rather than a core feature.

--- a/docs/ADR-003-repo-file-structure.md
+++ b/docs/ADR-003-repo-file-structure.md
@@ -91,7 +91,7 @@ as a complete historical artifact.
 - **Locale-based organization**: Establish clear structure for multilingual content (`en`, `uk`, `ru`)
 - **Historical preservation**: Maintain complete legacy Russian content as historical artifact
 - **Content root naming**: Clear directory name signaling "this contains course content"
-- **Maintainability**: Reduce cognitive load when navigating the repository
+- **Maintainability**: Reduce a cognitive load when navigating the repository
 - **Discoverability**: Clear separation between active and legacy content
 - **Content-asset colocation**: Keep related content and assets together within locales
 - **Build system compatibility**: Structure should support current and future SSG expectations (MkDocs)
@@ -323,7 +323,7 @@ This separation is cleaner than combining structure and format changes.
 
 ### Negative
 
-- **Implementation Effort**: Comprehensive reorganization requires careful execution (estimated 4--6 hours)
+- **Implementation Effort**: Comprehensive reorganization requires careful execution
 - **Repository Size Unchanged**: All content preserved (though organized)
 - **Temporary Sphinx Artifacts**: `_locales/` remains until ADR-002 completes (technical debt)
 - **Learning Curve**: Contributors familiar with `/src/` must adapt to `content/en/`

--- a/docs/ADR-004-presentation-framework.md
+++ b/docs/ADR-004-presentation-framework.md
@@ -242,8 +242,6 @@ with impress.js imported via `src/conf.js` webpack entry point.
 4. Verify webpack bundles impress.js correctly (npm run build)
 5. Test presentation functionality with bundled output
 
-**Estimated Implementation Time:** 5--10 minutes
-
 **Dependencies Resolved:**
 
 This decision removes the blocker for ADR-002 (SSG Replacement), as presentation requirements are now clarified and
@@ -267,7 +265,7 @@ asset organization is simplified.
 
 ### Negative
 
-- **One-time migration effort**: ~5--10 minutes to update presentation imports and remove submodule
+- **One-time migration effort**: update presentation imports and remove submodule
 - **Dependency added**: Project now has one additional npm dependency (minimal impact)
 - **Build process required**: Presentation now requires `npm install` and webpack build (already required for mermaid
   and other assets)
@@ -323,10 +321,12 @@ import 'impress.js';
 ```
 
 > [!IMPORTANT]
-> **Technical Detail:** The presentation HTML files reference webpack's **bundled output**
-> (e.g., `dist/presentation.js`), not npm package names directly.
+> **Technical Detail:** Presentation HTML files that are part of the webpack build reference webpack's **bundled
+> output** (currently `_build/webpack/js/main.bundle.js`, per `webpack.config.js`), not npm package names directly.
 > Changes are made to JavaScript import statements in webpack entry points, which webpack then bundles for browser
-> consumption.
+> consumption. Legacy standalone presentations (for example
+> `src/rdbms/presentations/normalization.html`) may still reference `assets/impress.js/...` directly; they are not
+> wired through the webpack bundle and should be updated or deprecated separately if needed.
 
 > [!NOTE]
 > **CSS Dependencies:** If the presentation uses impress.js CSS files, update those import paths as well following the


### PR DESCRIPTION
## Summary

This PR introduces three Architecture Decision Records addressing repository infrastructure and modernization:

1. **ADR-002** (Accepted): Static Site Generator Replacement
2. **ADR-003** (Accepted): Repository File Structure
3. **ADR-004** (Accepted): Presentation Framework Handling

**Status:** ✅ **ALL THREE ADRs ARE ACCEPTED** and ready for implementation

---

## ADR-004: Presentation Framework Handling ✅ ACCEPTED

**Status:** Accepted (v1.0)  
**Decision:** Migrate vendored impress.js submodule to npm dependency

### Problem

The repository contains a complete impress.js library vendored as a git submodule at `/assets/impress.js/`,
representing ~95% of the assets directory size (~33,000+ lines). This creates:

- Massive repository bloat
- Slow clone times for contributors
- Unclear maintenance responsibility

### Solution

**Option 5 (npm Dependency)** - Lowest-effort implementation:

- Remove git submodule at `/assets/impress.js/`
- Add `impress.js@^2.0.0` as npm dependency
- Leverage existing webpack 5 configuration (already handles mermaid the same way)
- Update single presentation HTML import path

### Impact

- ✅ **Dramatic size reduction**: Removes 95%+ of assets directory
- ✅ **Faster clones**: Significantly improved contributor experience
- ✅ **Modern dependency management**: Matches existing mermaid pattern
- ✅ **Self-contained**: Works offline (unlike CDN approach)
- ✅ **Minimal effort**: 5-10 minute implementation using existing infrastructure

### Next Steps

**Ready for immediate implementation** via work package to `project-administrator` (Claude Code).

---

## ADR-002: Static Site Generator Replacement ✅ ACCEPTED

**Status:** Accepted (v1.0)  
**Decision:** Migrate to MkDocs with Material Theme

### Problem

Current Sphinx setup creates contributor friction:

- reStructuredText learning curve vs. familiar Markdown
- Perceived as overkill for project needs
- Complex configuration vs. simpler alternatives
- Higher barrier to entry for new contributors

### Solution

**Option 1 (MkDocs with Material Theme):**

- Native Markdown support (CommonMark + extensions)
- Material theme provides professional appearance out-of-box
- mkdocs-static-i18n plugin for English/Ukrainian/Russian localization
- Simple configuration (single `mkdocs.yml` file)
- Fast build times and live reload for rapid iteration
- Excellent GitHub Pages integration

### Key Features

- **Localization**: Folder-based structure (`content/en/`, `content/uk/`, `content/ru/`)
- **Auto language switcher**: Material theme integration
- **Single unified build**: Produces `/`, `/uk/`, `/ru/` paths
- **Fallback support**: Missing translations fall back to default language

### Migration Strategy

### Impact

- ✅ **Improved contributor experience**: Markdown authoring
- ✅ **Faster iteration**: Live reload during development
- ✅ **Modern UI**: Professional appearance out-of-box
- ✅ **Simpler configuration**: Single YAML file vs. Python conf.py
- ✅ **Better i18n**: Single unified build for all languages

### Interdependencies

✅ **Resolved with ADR-003**: File structure decision finalized in parallel

### Next Steps

**Ready for phased implementation** via work package to `project-administrator` (Claude Code).

---

## ADR-003: Repository File Structure ✅ ACCEPTED

**Status:** Accepted (v1.0)  
**Decision:** Comprehensive repository reorganization

### Problem

Legacy Russian-language content scattered across repository root:

- All root `*.md` files (except `AGENTS.md`, `CLAUDE.md`) are legacy lessons
- Images scattered in `/pictures/lessonXX/` subdirectories
- Unclear distinction between current vs. historical content
- No clear locale organization for multilingual project
- Active content in `/src/` needs proper structure

### Solution

**Comprehensive Locale Reorganization:**

```
content/                 # MkDocs source directory (NEW)
├── en/                  # English content (default)
│   ├── index.md
│   ├── intro/
│   ├── linux/
│   └── ...
├── uk/                  # Ukrainian content
│   ├── index.md
│   └── ...
├── ru/                  # Russian legacy content
│   ├── index.md
│   └── ...
└── assets/              # Shared assets
    ├── images/
    └── icons/

src/                     # (TO BE REMOVED after migration)
```

### Key Decisions

1. **Treat Russian as localization**: Preserve as `content/ru/`, not "archive"
2. **Colocate content and assets**: Related files in same locale directory
3. **Establish i18n foundation**: Pattern ready for future locales
4. **Use git mv**: Preserve complete history during migration

### Migration Approach

- **Coordinate with ADR-002**: File structure migration happens as part of MkDocs migration
- **Single unified migration**: Avoid partial implementations and double work
- **Preserve history**: All moves use `git mv` operations

### Impact

- ✅ **Clearer structure**: Obvious locale organization
- ✅ **Reduced confusion**: Current vs. historical content clearly separated
- ✅ **Better colocation**: Content and assets together
- ✅ **Future-ready**: Foundation for additional locales
- ✅ **Historical respect**: Russian content preserved as foundational artifact

### Interdependencies

✅ **Resolved with ADR-002**: SSG decision finalized in parallel

### Next Steps

**Ready for implementation** as part of ADR-002 migration (Phase 2: Migration Preparation).

---

## Decision Relationships

```mermaid
graph TD
    A[ADR-002: SSG Replacement] <-->|decided together| B[ADR-003: File Structure]
    C[ADR-004: Presentation Framework] -->|unblocks| A
    C -->|simplifies| B
```

- **ADR-004 (Accepted)**: Independent decision, ready for immediate implementation
- **ADR-002 & ADR-003 (Accepted)**: Interdependent decisions, finalized together, ready for coordinated implementation
- **ADR-004 completed first**: Presentation requirements clarified, asset organization simplified

---

## Files Changed

### New Files

- `docs/ADR-002-ssg-replacement.md` (v1.0, accepted)
- `docs/ADR-003-repo-file-structure.md` (v1.0, accepted)
- `docs/ADR-004-presentation-framework.md` (v1.0, accepted)

### Documentation Impact

- Establishes ADR pattern for significant infrastructure decisions
- Creates foundation for future decision documentation
- Follows template from `templates/ADR.md`
- All three decisions accepted and ready for implementation

---

## Implementation Timeline

### Phase 1: Immediate (ADR-004)

✅ **Presentation Framework Migration**

- Deliverable: impress.js as npm dependency, submodule removed
- Impact: ~95% reduction in assets directory size
- **Status:** Ready for immediate execution

### Phase 2: Coordinated Migration (ADR-002 + ADR-003)

✅ **SSG Replacement + File Structure Reorganization**

- Deliverable: MkDocs with Material Theme, organized content structure
- Impact: Improved contributor experience, cleaner repository, modern UI
- **Status:** Ready for phased execution

### Implementation Order

1. **First:** Execute ADR-004 (independent, quick win)
2. **Second:** Execute ADR-002 + ADR-003 together (coordinated, comprehensive)

---

## Review Checklist

- [x] ADR-002: Accepted - MkDocs with Material Theme
- [x] ADR-003: Accepted - Comprehensive locale reorganization
- [x] ADR-004: Accepted - npm dependency for impress.js
- [x] Interdependencies resolved and clearly documented
- [x] Ready to proceed with implementation

---

## References

- [ADR Template](/../main/templates/ADR.md)
- [ADR-001: AI Guidelines Structure](/../main/docs/ADR-001-ai-guidelines-structure.md)
- [Upstream Repository](https://github.com/PonomaryovVladyslav/PythonCourses.git) (for ADR-003 context)

---

## Notes

### Why Three ADRs Together?

These decisions emerged during repository health assessment and are conceptually related:

- **ADR-004** addresses immediate bloat issue (independent, completed first)
- **ADR-002 & ADR-003** address long-term infrastructure (interdependent, finalized together)

Grouping them provides complete context for infrastructure modernization strategy.

### All Decisions Finalized

All three ADRs have been accepted and are ready for implementation. The implementation can proceed in two phases:

1. Quick win: ADR-004 (presentation framework)
2. Comprehensive migration: ADR-002 + ADR-003 together (SSG + file structure)

---

**Branch:** `docs/ADR-002-3-4`  
**Target:** `main` (or default branch)  
**Type:** Documentation (ADRs)  
**Breaking Changes:** None (documentation only at this stage)
