### PR TITLE
fix(docs): correct README filename reference in ADR-003

### DIFF
--- a/docs/ADR-003-repo-file-structure.md
+++ b/docs/ADR-003-repo-file-structure.md
@@ -407,7 +407,7 @@ Reorganization is considered successful when all the following are met:
 - [ ] `/assets/` unchanged at root
 - [ ] The root directory contains only infrastructure files
 - [ ] `content/ru/README.md` clearly explains legacy status
-- [ ] Root `README.md` updated with structure information
+- [ ] Root `README.rst` updated with structure information
 - [ ] `.ai/config.yaml` updated with new paths
 - [ ] Sphinx configuration updated and built successfully
 - [ ] Git history preserved for all moved files (verified with `git log --follow`)


### PR DESCRIPTION
Update verification checklist to reference README.rst instead of README.md to match the actual repository structure.

https://claude.ai/code/session_01DTcVXp4xonh5DstnLPxic9